### PR TITLE
feat: model init in  parallel

### DIFF
--- a/chatlearn/runtime/dist_actor.py
+++ b/chatlearn/runtime/dist_actor.py
@@ -283,7 +283,7 @@ class DistModel:
                 return dist_actor.rank_to_actors[rank]
 
     def register_serial_func(self):
-        for func_name in ["init"]:
+        for func_name in []:
             dist_call = partial(self.call_replica_serial_func, func_name)
             setattr(self, func_name, dist_call)
 
@@ -302,7 +302,8 @@ class DistModel:
                           "eval",
                           "train",
                           "set_src_parameter_model",
-                          "set_colocate"]:
+                          "set_colocate",
+                          "init"]:
             dist_call = partial(self.call_replica_func, func_name)
             setattr(self, func_name, dist_call)
 

--- a/chatlearn/runtime/engine.py
+++ b/chatlearn/runtime/engine.py
@@ -81,8 +81,10 @@ class BaseEngine:
             future.wait(ref_set_src)
         # include compile in init, compile dependencies need to be called serially
         logger.info(get_full_proc_memory_info('Before model init'))
+        ref_init = []
         for model in self.remote_models:
-            model.init()
+            ref_init += model.init()
+        future.wait(ref_init)
         logger.info(get_full_proc_memory_info('After model init'))
         # do not include compile dependencies in setup
         # if the program hang in setup, may try to set concurrent_setup to False.


### PR DESCRIPTION
将model init过程由模型间串行改成模型间并行。megatron的编译步骤的正确性交给其内部的lock file来保证，在llama2-7b（单机8卡）和70b（4机32卡）上测试均能跑通2个episode。不过合并代码前，**建议多重复跑几次验证正确性**