### PR TITLE
Fix get_use_legacy_models

### DIFF
--- a/chatlearn/utils/utils.py
+++ b/chatlearn/utils/utils.py
@@ -264,7 +264,11 @@ def dict_to_simplenamespace(d):
 
 
 def get_use_legacy_models(model_args):
-    use_legacy_models = model_args.get("use_legacy_models")
+    if isinstance(model_args, dict):
+        use_legacy_models = model_args.get("use_legacy_models", None)
+    else:
+        use_legacy_models = getattr(model_args, "use_legacy_models", None)
+
     if use_legacy_models is None:
         raise RuntimeError("Please specify use_legacy_models (True or False), but not None.")
     return use_legacy_models


### PR DESCRIPTION
This PR involves more robust get_use_legacy_models function to get `use_legacy_models` from `Namespace` object or `dict` object.