### PR TITLE
Fix: avoid creating empty FlatTensors

### DIFF
--- a/chatlearn/utils/flat_tensors.py
+++ b/chatlearn/utils/flat_tensors.py
@@ -254,7 +254,7 @@ class BucketizedFlatTensors:
         total_size = 0
         for t in tensors:
             size = t.numel() * t.element_size()
-            if total_size + size > size_limit:
+            if total_size + size > size_limit and len(bucket) > 0:
                 self._flat_tensors.append(
                     FlatTensors(bucket, primary_store_device, primary_store_shard_group)
                 )


### PR DESCRIPTION
When enabling efficient memory sharing (EMS) technique, a Tensor to be offloaded might be very large to exceed the `bucket_size_mb_in_memory_manager`. In this case, the code in [chatlearn/utils/flat_tensors.py#L255-265](https://github.com/alibaba/ChatLearn/blob/e641f6a00010af64038b07e95f1feabe6a3e0be2/chatlearn/utils/flat_tensors.py#L255-265) will create a `FlatTensors` object with an empty bucket. This is not the expected behavior. This PR resolves the issue.