### PR TITLE
[chore] Add `accelerate` to requirements.txt

### DIFF
--- a/docker/torch/Dockerfile.torch2.3.0
+++ b/docker/torch/Dockerfile.torch2.3.0
@@ -14,6 +14,7 @@ RUN pip install --no-cache-dir -U \
     pynvml==11.4.1 \
     deepspeed==0.14.4 \
     vllm==0.5.1 \
+    accelerate \
     jsonlines \
     torchtyping \
     tensorboard \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ transformers==4.42.0
 pynvml==11.4.1
 deepspeed==0.14.4
 vllm==0.5.1
-accelerate==1.0.0
+accelerate
 jsonlines
 torchtyping
 tensorboard

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ transformers==4.42.0
 pynvml==11.4.1
 deepspeed==0.14.4
 vllm==0.5.1
+accelerate==1.0.0
 jsonlines
 torchtyping
 tensorboard


### PR DESCRIPTION
The original `accelerate` version on my dev environment is v0.22.0 which doesn't have the function [is_mlu_available](https://github.com/huggingface/accelerate/blame/v1.0.0/src/accelerate/utils/imports.py#L329) which was added 7 months ago. Add `accelerate==1.0.0` to `requirements.txt`.