### PR TITLE
[chore] Print a message if `VLLMPolicyInference` is not available

### DIFF
--- a/examples/megatron/models/__init__.py
+++ b/examples/megatron/models/__init__.py
@@ -24,4 +24,5 @@ from .reference import PolicyReference
 try:
     from .vllm_policy_inference import VLLMPolicyInference
 except ImportError:
+    print("Cannot import VLLMPolicyInference")
     VLLMPolicyInference = None


### PR DESCRIPTION
When I run the online DPO example, an error is raised when the constructor of PolicyModel is called, stating `TypeError: 'NoneType' object is not callable`. I was very confused, but eventually discovered that it had been set to None without any message.

https://github.com/alibaba/ChatLearn/blob/7850c047726799628f85759a8fc76b547b8157d0/examples/megatron/entry/train_online_dpo.py#L43