### PR TITLE
[BUG] Fix NaN error for validating param sync

### DIFF
--- a/chatlearn/runtime/parameter_sync.py
+++ b/chatlearn/runtime/parameter_sync.py
@@ -360,7 +360,7 @@ class ParameterSyncGroup:
                 assert src_tensor.shape == dst_tensor.shape, \
                     f"after weight sync {src_name}: {src_tensor.shape} and {dst_name}: {dst_tensor.shape} do not match"
                 if not src_tensor.equal(dst_tensor):
-                    if src_tensor.isnan().any() or dst_tensor.isnan().any():
+                    if src_tensor.isnan().any() and dst_tensor.isnan().any():
                         logger.warning(
                             f"We have detected NaN values in parameter synchronization (from {src_name} to {dst_name}). We will "
                             "switch to `torch.allclose(input, other, rtol=0, atol=0, equal_nan=True)` to check if the two tensors "

--- a/chatlearn/runtime/parameter_sync.py
+++ b/chatlearn/runtime/parameter_sync.py
@@ -17,11 +17,11 @@
 import importlib
 import concurrent.futures
 import traceback
-import torch
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from itertools import cycle
 
+import torch
 from tqdm import tqdm
 
 from chatlearn.launcher.initialize import patch_ray
@@ -367,7 +367,6 @@ class ParameterSyncGroup:
                             "are equal, since `torch.equal` treats `nan == nan` as False. Nonetheless, NaN values are abnormal, "
                             "so please double-check your model."
                         )
-                        # For parameter synchronization, rtol and atol must be 0 to guarantee that the tensors are equal.
                         assert torch.allclose(src_tensor, dst_tensor, rtol=0, atol=0, equal_nan=True), \
                             f"after weight sync {src_name}: {src_tensor} and {dst_name}: {dst_tensor} do not match"
                     else:

--- a/chatlearn/runtime/parameter_sync.py
+++ b/chatlearn/runtime/parameter_sync.py
@@ -364,7 +364,7 @@ class ParameterSyncGroup:
                     dst_tensor_has_nan = dst_tensor.isnan().any()
                     if src_tensor_has_nan and dst_tensor_has_nan:
                         logger.warning(
-                            f"We have found NaN values in parameter synchronization (from {src_name} to {dst_name}). Switching "
+                            f"We have found NaN values in parameter synchronization (from {src_name} to {dst_name}). We will switch "
                             "to `torch.allclose(input, other, rtol=0, atol=0, equal_nan=True)` to check if the two tensors "
                             "are equal, since `torch.equal` treats `nan == nan` as False. Nonetheless, NaN values are abnormal, "
                             "so please double-check your model and code."

--- a/chatlearn/runtime/parameter_sync.py
+++ b/chatlearn/runtime/parameter_sync.py
@@ -364,8 +364,8 @@ class ParameterSyncGroup:
                     dst_tensor_has_nan = dst_tensor.isnan().any()
                     if src_tensor_has_nan and dst_tensor_has_nan:
                         logger.warning(
-                            f"We have detected NaN values in parameter synchronization (from {src_name} to {dst_name}). We will "
-                            "switch to `torch.allclose(input, other, rtol=0, atol=0, equal_nan=True)` to check if the two tensors "
+                            f"We have found NaN values in parameter synchronization (from {src_name} to {dst_name}). Switching "
+                            "to `torch.allclose(input, other, rtol=0, atol=0, equal_nan=True)` to check if the two tensors "
                             "are equal, since `torch.equal` treats `nan == nan` as False. Nonetheless, NaN values are abnormal, "
                             "so please double-check your model and code."
                         )
@@ -378,7 +378,7 @@ class ParameterSyncGroup:
                             )
                         elif dst_tensor_has_nan:
                             logger.warning(
-                                f"{dst_name}: {dst_tensor} has NaN values, while {src_name}: {src_tensor} does not have"
+                                f"{dst_name}: {dst_tensor} has NaN values, while {src_name}: {src_tensor} does not"
                             )
                         assert False, \
                             f"after weight sync {src_name}: {src_tensor} and {dst_name}: {dst_tensor} do not match"

--- a/chatlearn/runtime/parameter_sync.py
+++ b/chatlearn/runtime/parameter_sync.py
@@ -360,16 +360,26 @@ class ParameterSyncGroup:
                 assert src_tensor.shape == dst_tensor.shape, \
                     f"after weight sync {src_name}: {src_tensor.shape} and {dst_name}: {dst_tensor.shape} do not match"
                 if not src_tensor.equal(dst_tensor):
-                    if src_tensor.isnan().any() and dst_tensor.isnan().any():
+                    src_tensor_has_nan = src_tensor.isnan().any()
+                    dst_tensor_has_nan = dst_tensor.isnan().any()
+                    if src_tensor_has_nan and dst_tensor_has_nan:
                         logger.warning(
                             f"We have detected NaN values in parameter synchronization (from {src_name} to {dst_name}). We will "
                             "switch to `torch.allclose(input, other, rtol=0, atol=0, equal_nan=True)` to check if the two tensors "
                             "are equal, since `torch.equal` treats `nan == nan` as False. Nonetheless, NaN values are abnormal, "
-                            "so please double-check your model."
+                            "so please double-check your model and code."
                         )
                         assert torch.allclose(src_tensor, dst_tensor, rtol=0, atol=0, equal_nan=True), \
                             f"after weight sync {src_name}: {src_tensor} and {dst_name}: {dst_tensor} do not match"
                     else:
+                        if src_tensor_has_nan:
+                            logger.warning(
+                                f"{src_name}: {src_tensor} has NaN values, while {dst_name}: {dst_tensor} does not"
+                            )
+                        elif dst_tensor_has_nan:
+                            logger.warning(
+                                f"{dst_name}: {dst_tensor} has NaN values, while {src_name}: {src_tensor} does not have"
+                            )
                         assert False, \
                             f"after weight sync {src_name}: {src_tensor} and {dst_name}: {dst_tensor} do not match"
             return True


### PR DESCRIPTION
In validating parameter synchronization, comparing the src_tensor with dst_tensor by `torch.equal` will result in assertion error if NaN values presented. This PR bypasses such error by printing an warning message to the log and comparing the src_tensor with dst_tensor by `torch.allclose(.., rtol=0, atol=0, equal_nan=True)`.