### PR TITLE
fix attribute error when sync megatron and vllm

### DIFF
--- a/chatlearn/models/base_module.py
+++ b/chatlearn/models/base_module.py
@@ -1320,3 +1320,15 @@ class BaseModule:
 
     def get_pipeline_stage_layer_offset(self):
         return 0
+
+    def expert_parallel_rank(self):
+        """
+        :meta private:
+        """
+        return 0
+
+    def tensor_and_expert_parallel_rank(self):
+        """
+        :meta private:
+        """
+        return 0


### PR DESCRIPTION
fix attribute error when sync megatron and vllm, which is introduced in https://github.com/alibaba/ChatLearn/commit/a88ef5826472b453e4555b34193eb70dcfd99db7