### PR TITLE
fix attr error and remove assert error for non-MoE qwen model.

### DIFF
--- a/chatlearn/models/megatron_module.py
+++ b/chatlearn/models/megatron_module.py
@@ -168,9 +168,12 @@ class MegatronModule(TorchModule):
         get expert_model_parallel_size
         :meta private:
         """
+        if hasattr(self.megatron_args, "moe_expert_model_parallel_size"):
+            return self.megatron_args.moe_expert_model_parallel_size
         if hasattr(self.megatron_args, "expert_model_parallel_size"):
             return self.megatron_args.expert_model_parallel_size
-        return self.megatron_args.moe_expert_model_parallel_size
+        return 1
+
 
     def tensor_and_expert_model_parallel_size(self):
         """
@@ -209,13 +212,17 @@ class MegatronModule(TorchModule):
         """
         :meta private:
         """
-        return mpu.get_expert_model_parallel_rank()
+        if hasattr(mpu, "get_expert_model_parallel_rank"):
+            return mpu.get_expert_model_parallel_rank()
+        return 0
 
     def tensor_and_expert_parallel_rank(self):
         """
         :meta private:
         """
-        return mpu.get_tensor_and_expert_parallel_rank()
+        if hasattr(mpu, "get_expert_model_parallel_rank"):
+            return mpu.get_tensor_and_expert_parallel_rank()
+        return self.tensor_parallel_rank()
 
     def num_layers(self):
         """

--- a/chatlearn/runtime/parameter_sync.py
+++ b/chatlearn/runtime/parameter_sync.py
@@ -462,7 +462,10 @@ class ParameterSyncGroup:
 
             src_names, dst_names = future.get([send_actor.get_parameter_to_sync_names.remote(pipe_stage),
                                                recv_actors[0].get_parameter_to_sync_names.remote(pipe_stage)])
-            assert len(src_names) == len(dst_names)
+
+            assert len(src_names) == len(dst_names), (
+                f"expect the length of src_names and dst_names being the same, got {len(src_names)} and {len(dst_names)}"
+            )
 
             # check the value of src model and tgt model
             names = list(zip(src_names, dst_names))
@@ -738,18 +741,12 @@ class ParameterSyncGroup:
             refs.append(send_actor.set_sync_parameters.remote(src_names, pipe_stage))
             refs.append(recv_actor.set_sync_parameters.remote(dst_names, pipe_stage))
             future.get(refs)
-        assert len(src_names) == len(dst_names), (
-            f"expect the length of src_names and dst_names being the same, got {len(src_names)} and {len(dst_names)}"
-        )
         return src_names, dst_names
 
     def set_sync_param_names(self, send_actor, recv_actor, requires_grad=None, filter_fn=None, param_group="default"):
         src_names, dst_names = utils.get_or_cache(self._send_recv_param_names, (send_actor, recv_actor), \
             lambda: self._set_sync_param_names(send_actor, recv_actor, requires_grad, filter_fn, param_group))
         logger.debug(f"{self.actor2rank[send_actor]} -> {self.actor2rank[recv_actor]}: {src_names} -> {dst_names}")
-        assert len(src_names) == len(dst_names), (
-            f"expect the length of src_names and dst_names being the same, got {len(src_names)} and {len(dst_names)}"
-        )
         pipe_stage = self.get_actor_pipe_rank(send_actor)
         if vllm_exist and isinstance(self.dst_model.replicas[0].model, VLLMModule):
             refs = []

--- a/chatlearn/utils/vllm_utils.py
+++ b/chatlearn/utils/vllm_utils.py
@@ -355,7 +355,8 @@ class Megatron2QWenSyncMap(ParameterSyncMap):
         self.src_prefix = src_prefix
         self.dst_prefix = dst_prefix
         self._embedding_sync_map = {
-            f"{src_prefix}.embedding.word_embeddings.weight": f"{dst_prefix}.{embed_name}.weight"
+            f"{src_prefix}.embedding.word_embeddings.weight": f"{dst_prefix}.{embed_name}.weight",
+            "module.module.word_embeddings.weight": f"{dst_prefix}.{embed_name}.weight"
         }
         self._layer_sync_map = {
             "attention.attention_layernorm": ".attn.attention_layernorm.",


### PR DESCRIPTION
For non-MoE qwen model,  megatron splits weight `gate_up_proj` in vlm model into weight `w1` and `w2`, thus assert error is not compatible, and attributes related to expert parallism are not defined, we need to set default value.