### PR TITLE
fix(chatlearn/models/megatron): add __init__ to load pkg properly 

### DIFF
--- a/chatlearn/models/megatron/__init__.py
+++ b/chatlearn/models/megatron/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""megatron"""


### PR DESCRIPTION
when pip install chatlearn, error with import chatlearn.models.megatron cause of __init__ missing file.