### PR TITLE
docs[programming]: fix outdated hyperlink to configuration file

### DIFF
--- a/docs/en/programming.md
+++ b/docs/en/programming.md
@@ -37,7 +37,7 @@ engine.learn()
 ```
 
 1. Call `chatlearn.init()` to initialize the runtime environment of ChatLearn.
-2. Define models, where each model needs to define a unique `model_name`. Different model configurations are distinguished by `model_name`. See [training configuration file](config_yaml) for details.
+2. Define models, where each model needs to define a unique `model_name`. Different model configurations are distinguished by `model_name`. See [training configuration file](config_yaml.md) for details.
 3. Define the engine [RLHFEngine](api/engine.rst).
 4. Define evaluator (optional)
 4. Set the training dataset.

--- a/docs/zh/programming.md
+++ b/docs/zh/programming.md
@@ -45,7 +45,7 @@ engine.learn()
 ```
 
 1. 调用 `chatlearn.init()` 初始化 ChatLearn 的运行环境。
-2. 定义模型, 其中每个模型需要定义一个唯一的 `model_name`。在配置模型参数的时候，不同模型的配置通过   `model_name` 来区分。详见[训练配置文件](config_yaml)。
+2. 定义模型, 其中每个模型需要定义一个唯一的 `model_name`。在配置模型参数的时候，不同模型的配置通过   `model_name` 来区分。详见[训练配置文件](config_yaml.md)。
 3. 定义 engine [RLHFEngine](api/engine.rst)。
 4. 定义 evaluator (可选)
 4. 设置训练数据集。


### PR DESCRIPTION
This PR fixes outdated hyperlink to configuration file in programming.md