### PR TITLE
align default_value of skip_special_tokens

### DIFF
--- a/chatlearn/models/vllm_module.py
+++ b/chatlearn/models/vllm_module.py
@@ -515,7 +515,7 @@ class VLLMModule(TorchModule, LLMEngine, LLM):
                     max_tokens=max_tokens,
                     logprobs=1,
                     prompt_logprobs=self.model_args.get("prompt_logprobs", None),
-                    skip_special_tokens=False
+                    skip_special_tokens=self.model_args.get('skip_special_tokens', True)
                 )
             elif CURRENT_VLLM_VERSION == VLLMVersion.v_0_6_3:
                 sampling_params = SamplingParams(
@@ -531,7 +531,7 @@ class VLLMModule(TorchModule, LLMEngine, LLM):
                     max_tokens=max_tokens,
                     logprobs=1,
                     prompt_logprobs=self.model_args.get("prompt_logprobs", None),
-                    skip_special_tokens=False
+                    skip_special_tokens=self.model_args.get('skip_special_tokens', True)
                 )
             else:
                 raise RuntimeError(f"Unsupported vllm version {CURRENT_VLLM_VERSION}, expect one of {list(VLLMVersion)}")

--- a/chatlearn/models/vllm_module_v2.py
+++ b/chatlearn/models/vllm_module_v2.py
@@ -229,7 +229,7 @@ class VLLMModuleV2(TorchModule, RayWorkerWrapper):
             stop=stop,
             logprobs=1,
             prompt_logprobs=self.model_args.get("prompt_logprobs", None),
-            skip_special_tokens=False
+            skip_special_tokens=self.model_args.get('skip_special_tokens', True)
         )
         # VLLMVersion.v_0_3_0, VLLMVersion.v_0_5_1
         if hasattr(sampling_params, 'use_beam_search'):

--- a/examples/megatron/configs/llama2/vllm_policy_inference.yaml
+++ b/examples/megatron/configs/llama2/vllm_policy_inference.yaml
@@ -23,6 +23,7 @@ apply_replica_id_to_seed: ${apply_replica_id_to_seed:True}
 stop_token_list: ${stop_token_list:<EOS>;</s>}
 new_token_limit: ${new_token_limit:True}
 prompt_logprobs: ${prompt_logprobs:None}
+skip_special_tokens: ${skip_special_tokens:True}
 
 # scheduler config
 max_num_batched_tokens: ${max_num_batched_tokens:32768}


### PR DESCRIPTION
set skip_special_tokens for sampling_params when there is a corresponding argument, and reset default value to True.