### PR TITLE
Force forward_step and train_step have same data order

### DIFF
--- a/chatlearn/algorithm/grpo_utils/advantage_compute.py
+++ b/chatlearn/algorithm/grpo_utils/advantage_compute.py
@@ -1,6 +1,5 @@
 """compute advantage for grpo"""
 from collections import defaultdict
-import random
 
 import torch
 

--- a/chatlearn/algorithm/grpo_utils/advantage_compute.py
+++ b/chatlearn/algorithm/grpo_utils/advantage_compute.py
@@ -26,5 +26,6 @@ def compute_grpo_adv(episode_replay_buffers):
 
     # Sort samples by original order in buffer
     res_buffers.sort(key=lambda x: x["sample_id"])
-
+    for data in res_buffers:
+        data.pop("sample_id")
     return res_buffers

--- a/chatlearn/algorithm/grpo_utils/advantage_compute.py
+++ b/chatlearn/algorithm/grpo_utils/advantage_compute.py
@@ -7,8 +7,11 @@ import torch
 def compute_grpo_adv(episode_replay_buffers):
     buffers = episode_replay_buffers[-1].buffer
     queryids2samples = defaultdict(list)
+    sample_id = 0
     for s in buffers:
+        s['sample_id'] = sample_id
         queryids2samples[hash(",".join(map(str, s["prompt_token_ids"])))].append(s)
+        sample_id += 1
 
     res_buffers = []
     for _, l in queryids2samples.items():
@@ -20,6 +23,8 @@ def compute_grpo_adv(episode_replay_buffers):
         for i, li in enumerate(l):
             li["advantages"] = (rewards[i] - mean) / (std + 1e-5)
         res_buffers.extend(l)
-    # Shuffle train sample to balance training workload across dp_ranks
-    random.shuffle(res_buffers)
+
+    # Sort samples by original order in buffer
+    res_buffers.sort(key=lambda x: x["sample_id"])
+
     return res_buffers

--- a/chatlearn/runtime/executor.py
+++ b/chatlearn/runtime/executor.py
@@ -297,34 +297,23 @@ class Executor:
 
         replica_num = len(model.replicas)
         output = []
+        last_step_start = max(self.num_iteration(model) - replica_num, 0)
+        is_last_batch = step_num >= last_step_start
+        kwargs["is_last_batch"] = is_last_batch
+        if is_eval is not None:
+            kwargs["is_eval"] = is_eval
+        if to_empty_cache is not None:
+            kwargs["to_empty_cache"] = to_empty_cache
+        if to_onload is not None:
+            kwargs["to_onload"] = to_onload
+        if to_offload is not None:
+            kwargs["to_offload"] = to_offload
         if isinstance(replica.model, VLLMModule):
-            last_step_start = max(self.num_iteration(model) - replica_num, 0)
-            is_last_batch = step_num >= last_step_start
-            kwargs["is_last_batch"] = is_last_batch
-            if is_eval is not None:
-                kwargs["is_eval"] = is_eval
-            if to_empty_cache is not None:
-                kwargs["to_empty_cache"] = to_empty_cache
-            if to_onload is not None:
-                kwargs["to_onload"] = to_onload
-            if to_offload is not None:
-                kwargs["to_offload"] = to_offload
             mb, query = self.get_next_data(in_queue, model_node, micro_batch_index)
             assert isinstance(query, list)
             ret = replica.call_actor_remote_func(replica.vllm_engine, func_name, *query, **kwargs)
             output.append((ret, mb))
         else:
-            last_step_start = max(self.num_iteration(model) - replica_num, 0)
-            is_last_batch = step_num >= last_step_start
-            kwargs["is_last_batch"] = is_last_batch
-            if to_empty_cache is not None:
-                kwargs["to_empty_cache"] = to_empty_cache
-            if to_onload is not None:
-                kwargs["to_onload"] = to_onload
-            if to_offload is not None:
-                kwargs["to_offload"] = to_offload
-            if is_eval is not None:
-                kwargs["is_eval"] = is_eval
             for _, actors in replica.dp_rank_to_actors.items():
                 mb, query = self.get_next_data(in_queue, model_node, micro_batch_index)
                 assert isinstance(query, list)

--- a/chatlearn/runtime/trainer.py
+++ b/chatlearn/runtime/trainer.py
@@ -100,13 +100,14 @@ class Trainer(Executor):
 
             data_queues, out_queue = self.setup_queues()
             batch_list = []
-            # get batch by iterate over dp first, iteration second
+            # Data will merge by dp_rank order after environment.make_experiences()
+            # For off-policy, we need to get batch by iterate over dp first, iteration second
             for dp_rank in range(self.data_parallel_size):
                 for iter_ in range(_num_training_iteration):
                     batch = encode_data(iter_ * self.data_parallel_size + dp_rank, self.next_batch())
                     batch_list.append(batch)
-            
-            # put batch by iterate over iteration first, dp second
+
+            # After get all batches, put batch into trainer's input queue by iterate over iteration first, dp second
             for iter_ in range(_num_training_iteration):
                 for dp_rank in range(self.data_parallel_size):
                     for data_queue in data_queues:

--- a/scripts/train_fsdp_vllm_qwen3_235b_a22b_grpo.sh
+++ b/scripts/train_fsdp_vllm_qwen3_235b_a22b_grpo.sh
@@ -13,7 +13,7 @@ python chatlearn/entrypoint.py grpo \
         --config-file template/grpo_fsdp.yaml \
         runtime_args.exp_name=${exp_name} \
         runtime_args.data_path=${CHATLEARN}/dataset/MATH-lighteval/train.json \
-        runtime_args.eval_data_path=${CHATLEARN}/dataset/MATH-lighteval/train.json \
+        runtime_args.eval_data_path=${CHATLEARN}/dataset/MATH-lighteval/test.json \
         runtime_args.output_dir=${CHATLEARN}/output/${exp_name} \
         runtime_args.num_episode=200 \
         runtime_args.sample_per_episode=2048 \

--- a/scripts/train_fsdp_vllm_qwen3_30b_a3b_grpo.sh
+++ b/scripts/train_fsdp_vllm_qwen3_30b_a3b_grpo.sh
@@ -13,7 +13,7 @@ python chatlearn/entrypoint.py grpo \
         --config-file template/grpo_fsdp.yaml \
         runtime_args.exp_name=${exp_name} \
         runtime_args.data_path=${CHATLEARN}/dataset/MATH-lighteval/train.json \
-        runtime_args.eval_data_path=${CHATLEARN}/dataset/MATH-lighteval/train.json \
+        runtime_args.eval_data_path=${CHATLEARN}/dataset/MATH-lighteval/test.json \
         runtime_args.output_dir=${CHATLEARN}/output/${exp_name} \
         runtime_args.num_episode=200 \
         runtime_args.sample_per_episode=512 \


### PR DESCRIPTION
For onpolicy:
- keep buffer always have same order 

For offpolicy
- Since merge output from environment follow dp_rank order, get batch from StreamDataset by loop over iteration first and dp_rank second 
- Put batch into queue by loop over dp_rank first and iteration second