### PR TITLE
Extend parser to support Optional[type] and custom callable

### DIFF
--- a/chatlearn/algorithm/grpo.py
+++ b/chatlearn/algorithm/grpo.py
@@ -116,7 +116,9 @@ class GrpoConfig(BaseConfig):
         self.models.policy_trainer = convert_to_dataclass(
             policytrainer_cls, self.models.policy_trainer
         )
-        _config_validate(self)
+    
+    def validate(self):
+        return _config_validate(self)
 
 
 class GRPOEvaluator(Evaluator):

--- a/chatlearn/configs/common.py
+++ b/chatlearn/configs/common.py
@@ -10,7 +10,7 @@ from omegaconf import MISSING
 
 from chatlearn.utils.constant import RAY_PG_STRATEGY
 
-
+@dataclass
 class BaseConfig:
     # TODO: Unifying Parameter Access Using dataclass approach
     def __setitem__(self, key, value):
@@ -44,6 +44,9 @@ class BaseConfig:
     def values(self) -> Iterator[Any]:
         """support args.values()"""
         return asdict(self).values()
+
+    def validate(self):
+        return True
 
 
 @dataclass

--- a/chatlearn/configs/megatron_config.py
+++ b/chatlearn/configs/megatron_config.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-module-docstring
 # pylint: disable=missing-class-docstring
+from typing import Optional
 from dataclasses import dataclass, field
 
 from omegaconf import MISSING
@@ -32,7 +33,7 @@ class MegatronModelArchitectureConfig(BaseConfig):
         default=MISSING,
         metadata={"help": "Transformer Feed-Forward Network hidden size. "},
     )
-    num_query_groups: int = field(
+    num_query_groups: Optional[int] = field(
         default=None, metadata={"help": "num query groups"}
     )
     max_position_embeddings: int = field(
@@ -78,7 +79,7 @@ class MegatronModelArchitectureConfig(BaseConfig):
     kv_channels: int = field(
         default=MISSING, metadata={"help": "kv channels"}
     )
-    num_experts: int = field(
+    num_experts: Optional[int] = field(
         default=None,
         metadata={"help": "Number of Experts in MoE (None means no MoE)"},
     )
@@ -99,7 +100,7 @@ class MegatronModelArchitectureConfig(BaseConfig):
         default="aux_loss",
         metadata={"help": "Determines the load balancing strategy for the router."},
     )
-    moe_router_dtype: str = field(
+    moe_router_dtype: Optional[str] = field(
         default=None,
         metadata={"help": "Data type for routing and expert output weighted averaging. Using fp32 or fp64 can \
     improve stability especially when the number of experts is large"},
@@ -114,14 +115,14 @@ class MegatronModelArchitectureConfig(BaseConfig):
     - An integer N: Represents a 1:N ratio, meaning one expert layer for every N-1 dense layers. \
     - A list that defines a custom pattern, e.g.: [1,1,1,0,1,1,1,0,1,1,1,0]"},
     )
-    moe_ffn_hidden_size: int = field(
+    moe_ffn_hidden_size: Optional[int] = field(
         default=None,
         metadata={"help": "The hidden size of each expert\'s feed-forward network (ffn). "},
     )
     moe_aux_loss_coeff: float = field(
         default=0.0, metadata={"help": "Scaling coefficient for the aux loss: a starting value of 1e-2 is recommended."}
     )
-    q_lora_rank: int = field(
+    q_lora_rank: Optional[int] = field(
         default=None,
         metadata={"help": "Rank of Key and Value tensors' low rank representation."},
     )
@@ -129,15 +130,15 @@ class MegatronModelArchitectureConfig(BaseConfig):
         default=32,
         metadata={"help": "Rank of Key and Value tensors' low rank representation."},
     )
-    moe_router_num_groups: int = field(
+    moe_router_num_groups: Optional[int] = field(
         default=None,
         metadata={"help": "Number of groups to divide experts into for group-limited routing"},
     )
-    moe_router_group_topk: int = field(
+    moe_router_group_topk: Optional[int] = field(
         default=None,
         metadata={"help": "Number of selected groups for group-limited routing."},
     )
-    moe_shared_expert_intermediate_size: int = field(
+    moe_shared_expert_intermediate_size: Optional[int] = field(
         default=None,
         metadata={"help": "Shared expert total ffn hidden size. "},
     )
@@ -151,7 +152,7 @@ class MegatronModelArchitectureConfig(BaseConfig):
     multi_latent_attention: bool = field(
         default=False, metadata={"help": "Use multi-latent attention for model."}
     )
-    v_head_dim: int = field(
+    v_head_dim: Optional[int] = field(
         default=None,
         metadata={"help": "v_head_dim "},
     )
@@ -188,13 +189,13 @@ class MegatronModelArchitectureConfig(BaseConfig):
 
 @dataclass
 class MegatronTrainConfig(BaseConfig):
-    expert_tensor_parallel_size: int = field(
+    expert_tensor_parallel_size: Optional[int] = field(
         default=None, metadata={"help": "expert tensor parallel size for Megatron-Core"}
     )
-    decoder_first_pipeline_num_layers: int = field(
+    decoder_first_pipeline_num_layers: Optional[int] = field(
         default=None, metadata={"help": "The number of transformer layers on the first pipeline stage of the decoder."}
     )
-    decoder_last_pipeline_num_layers: int = field(
+    decoder_last_pipeline_num_layers: Optional[int] = field(
         default=None, metadata={"help": "The number of transformer layers on the last pipeline stage of the decoder."}
     )
     load: str = field(default=MISSING, metadata={"help": "path to train model"})
@@ -202,7 +203,7 @@ class MegatronTrainConfig(BaseConfig):
     tokenizer_type: str = field(
         default="NullTokenizer", metadata={"help": "What type of tokenizer to use."}
     )
-    tokenizer_model: str = field(
+    tokenizer_model: Optional[str] = field(
         default=None, metadata={"help": "pretrained model name or path"}
     )
     seq_length: int = field(
@@ -233,7 +234,7 @@ class MegatronTrainConfig(BaseConfig):
                        from checkpoint and ignore input arguments."
         },
     )
-    recompute_granularity: str = field(
+    recompute_granularity: Optional[str] = field(
         default=None,
         metadata={
             "help": "Checkpoint activations to allow for training with larger models, sequences, and batch sizes. \
@@ -318,17 +319,17 @@ class MegatronRefPolicyConfig(BaseModelConfig):
     tokenizer_type: str = field(
         default="NullTokenizer", metadata={"help": "What type of tokenizer to use."}
     )
-    tokenizer_model: str = field(
+    tokenizer_model: Optional[str] = field(
         default=None, metadata={"help": "pretrained model name or path"}
     )
     bf16: bool = field(default=True, metadata={"help": "Run model in bfloat16 mode."})
-    expert_tensor_parallel_size: int = field(
+    expert_tensor_parallel_size: Optional[int] = field(
         default=None, metadata={"help": "expert tensor parallel size for Megatron-Core"}
     )
-    decoder_first_pipeline_num_layers: int = field(
+    decoder_first_pipeline_num_layers: Optional[int] = field(
         default=None, metadata={"help": "The number of transformer layers on the first pipeline stage of the decoder."}
     )
-    decoder_last_pipeline_num_layers: int = field(
+    decoder_last_pipeline_num_layers: Optional[int] = field(
         default=None, metadata={"help": "The number of transformer layers on the last pipeline stage of the decoder."}
     )
     moe_router_force_load_balancing: bool = field(

--- a/chatlearn/entrypoint.py
+++ b/chatlearn/entrypoint.py
@@ -99,7 +99,9 @@ class ChatlearnLauncher:
             if algo_args.config_file is not None:
                 external_cfg = OmegaConf.load(algo_args.config_file)
                 keynames, values = list(zip(*[arg.split('=', 1) for arg in algo_args.hydra_args if '=' in arg]))
-                parsers = find_parser_from_keyname(config_cls, keynames)
+                # NOTE: we assume default_merged_config is runable
+                default_merged_config = OmegaConf.to_object(OmegaConf.merge(cfg, external_cfg))
+                parsers = find_parser_from_keyname(default_merged_config, keynames)
                 for keyname, value in zip(keynames, values):
                     parser = parsers[keyname]
                     if parser is None:

--- a/chatlearn/entrypoint.py
+++ b/chatlearn/entrypoint.py
@@ -95,11 +95,9 @@ class ChatlearnLauncher:
         GlobalHydra.instance().clear()
         with hydra.initialize(config_path=None, version_base=None):
             cfg = hydra.compose(config_name=algo_args.algorithm)
-
             if algo_args.config_file is not None:
                 external_cfg = OmegaConf.load(algo_args.config_file)
                 keynames, values = list(zip(*[arg.split('=', 1) for arg in algo_args.hydra_args if '=' in arg]))
-                # NOTE: we assume default_merged_config is runable
                 default_merged_config = OmegaConf.to_object(OmegaConf.merge(cfg, external_cfg))
                 parsers = find_parser_from_keyname(default_merged_config, keynames)
                 for keyname, value in zip(keynames, values):
@@ -113,6 +111,7 @@ class ChatlearnLauncher:
                     OmegaConf.update(external_cfg, keyname, value)
                 cfg = OmegaConf.merge(cfg, external_cfg) # include $
             cfg = OmegaConf.to_object(cfg) # real cfg
+            cfg.validate()
             instance = algo_cls(cfg)
             instance.run()
 

--- a/chatlearn/models/patches/monkey_patch.py
+++ b/chatlearn/models/patches/monkey_patch.py
@@ -33,4 +33,4 @@ def apply_group_gemm(model):
             # pylint: disable=import-outside-toplevel
         apply_group_gemm_patch(model)
     else:
-        raise ValueError(f"Unsupported model architecture: {model_config.architectures} for groupgemm patch")
+        raise ValueError(f"Unsupported model architecture: {model.config.architectures} for groupgemm patch")

--- a/chatlearn/utils/parse_utils.py
+++ b/chatlearn/utils/parse_utils.py
@@ -22,6 +22,8 @@ from omegaconf import DictConfig
 def parse_optional(dtype, data):
     if data is None:
         return None
+    if isinstance(data, str) and data.lower() in ["none", "null"]:
+        return None
     return dtype(data)
 
 def parse_boolean(data: Union[str, bool]):

--- a/chatlearn/utils/parse_utils.py
+++ b/chatlearn/utils/parse_utils.py
@@ -1,0 +1,76 @@
+# Copyright 2024 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from functools import partial
+from dataclasses import fields, dataclass, is_dataclass
+from typing import get_origin, get_args, Dict, List, Union, Type, Optional, Callable, Any
+from chatlearn.configs.common import BaseConfig
+from omegaconf import DictConfig
+
+
+def parse_optional(dtype, data):
+    if data is None:
+        return None
+    return dtype(data)
+
+def parse_boolean(data: Union[str, bool]):
+    if isinstance(data, bool):
+        return data
+    return data.lower() == "true"
+def _resolve_type_from_dataclass(dt: dataclass) -> Dict:
+    dtypes = {}
+    for f in fields(dt):
+        dtypes[f.name] = None
+        # NOTE: Optional -> Union, List -> list, Union -> Union, Tuple -> tuple
+        # NOTE: iteratively resolve nested dataclass
+        if is_dataclass(f.type):
+            dtypes[f.name] = _resolve_type_from_dataclass(f.type)
+        elif get_origin(f.type) is Union:
+            # we only process optional here
+            args = get_args(f.type)
+            if len(args) == 2 and args[1] is type(None):
+                dtypes[f.name] = partial(parse_optional, args[0])
+        elif f.type is bool:
+            dtypes[f.name] = parse_boolean
+        elif f.type is not Any and callable(f.type):
+            dtypes[f.name] = f.type
+    return dtypes
+
+def _find_type(dtypes, key: str):
+    def _inner_find(dtypes, level, key_list):
+        dtype = dtypes[key_list[level]]
+        if isinstance(dtype, dict):
+            return _inner_find(dtype, level+1, key_list)
+        return dtype
+    return _inner_find(dtypes, 0, key.split("."))
+
+def find_parser_from_keyname(
+    dt: Type, 
+    keynames: List[str]
+) -> Dict[str, Optional[Callable]]:
+    """Find datatype parser according to keyname by searching
+    in dataclass.
+
+    Args:
+        dt (Type): The type of some dataclass containing keyname.
+        keynames (List[str]): The list of keynames to be parsed.
+
+    Returns:
+        Dict[str, Optional[Callable]]: mapping keyname to its parser.
+        Maybe None if no parser found.
+    """
+    dtypes = _resolve_type_from_dataclass(dt)
+    return {
+        k: _find_type(dtypes, k.lstrip('+')) for k in keynames
+    }


### PR DESCRIPTION
Now parser attempts to parse values from yaml/console in the following order:

1. if type-hint is `Any`, get the type of the default value
2. if the parsed type is Union,  check if is Optional, if True, return a callable to parse optional; otherwise return None
3. if the parsed type is bool, return a callable to parse bool
4. if the parsed type is callable, return type
5. no parser, return None

If parser is not None, call `user_input=parser(user_input)`, otherwise do nothing