### PR TITLE
Add GSPO for Mcore Models

### DIFF
--- a/chatlearn/algorithm/grpo_utils/loss_gallery.py
+++ b/chatlearn/algorithm/grpo_utils/loss_gallery.py
@@ -70,3 +70,4 @@ def calculate_gspo_loss(
     assert not torch.isnan(loss).any(), "pg loss is nan"
 
     return (loss.contiguous(), is_positive_clipped, is_negative_clipped, is_clipped)
+    

--- a/chatlearn/algorithm/grpo_utils/loss_gallery.py
+++ b/chatlearn/algorithm/grpo_utils/loss_gallery.py
@@ -48,9 +48,4 @@ def calculate_grpo_loss(
     # check pg_loss nan
     assert not torch.isnan(loss).any(), "pg loss is nan"
 
-    return (
-        loss.contiguous(), 
-        is_positive_clipped, 
-        is_negative_clipped,
-        is_clipped,
-    )
+    return (loss.contiguous(), is_positive_clipped, is_negative_clipped, is_clipped)

--- a/chatlearn/algorithm/grpo_utils/loss_gallery.py
+++ b/chatlearn/algorithm/grpo_utils/loss_gallery.py
@@ -1,6 +1,7 @@
 """pg loss"""
 import torch
 
+
 def calculate_grpo_loss(
     log_probs: torch.Tensor,
     old_log_probs: torch.Tensor,
@@ -8,27 +9,19 @@ def calculate_grpo_loss(
     diff_clip_ratio: float = 10,
     pos_clip_ratio: float = 0.2,
     neg_clip_ratio: float = 0.2,
-    final_clip_ratio: float = 0.01
+    final_clip_ratio: float = 0.01,
 ):
-
     logprobs_diff = log_probs - old_log_probs
     # clip logprobs_diff before exp to avoid overflow
     logprobs_diff = torch.clamp(logprobs_diff, max=diff_clip_ratio)
 
     ratio = torch.exp(logprobs_diff)
-    advantages.unsqueeze_(-1)
-
-    pg_loss = -advantages * ratio
+    pg_loss = -advantages.unsqueeze(-1) * ratio
     # Upper and lower bound clip
-    is_positive_clipped = (ratio > (1 + pos_clip_ratio)) * (advantages > 0)
-    is_negative_clipped = (ratio < (1 - neg_clip_ratio)) * (advantages < 0)
-
-    pg_loss_2 = -advantages * torch.clamp(
+    pg_loss_2 = -advantages.unsqueeze(-1) * torch.clamp(
         ratio, 1 - neg_clip_ratio, 1 + pos_clip_ratio
     )
     pg_loss_clip = torch.max(pg_loss, pg_loss_2)
-
-    is_clipped = pg_loss_2 > pg_loss
     pg_loss_upperbound = torch.ones_like(pg_loss) * final_clip_ratio
     # final clip on loss
     loss = torch.min(pg_loss_clip, pg_loss_upperbound)

--- a/chatlearn/algorithm/grpo_utils/loss_gallery.py
+++ b/chatlearn/algorithm/grpo_utils/loss_gallery.py
@@ -1,28 +1,10 @@
 """pg loss"""
 import torch
 
-def masked_sum(values, mask, axis=None):
-    """Compute mean of tensor with a masked values."""
-    # If NaNs exist out of mask, replace NaNs in values with a value that
-    # won't affect the sum (e.g., 0 for masked regions)
-    valid_values = torch.where(mask.bool(), values, 0.0)
-    return (valid_values * mask).sum(axis=axis)
-
-def masked_mean(values, mask, axis=None):
-    """
-    Compute the mean of `values` over elements selected by `mask`.
-
-    Args:
-        values (Tensor): Input tensor.
-        mask (Tensor): Boolean or numeric mask of the same shape as `values`.
-        axis (int or tuple of int, optional): Dimension(s) along which to compute the mean.
-            Defaults to None (over all elements).
-
-    Returns:
-        Tensor: Masked mean, with shape equal to `values` reduced over `axis`.
-    """
-    s = masked_sum(values, mask, axis)
-    return s / (mask.sum(axis=axis) + 1e-8)
+def loss_masked_mean(values, loss_mask, axis=None):
+    valid_values = torch.where(loss_mask.bool(), values, 0.0)
+    s = (valid_values * loss_mask).sum(axis=axis)
+    return s / (loss_mask.sum(axis=axis) + 1e-8)
 
 def calculate_grpo_loss(
     log_probs: torch.Tensor,
@@ -32,16 +14,16 @@ def calculate_grpo_loss(
     pos_clip_ratio: float = 0.2,
     neg_clip_ratio: float = 0.2,
     final_clip_ratio: float = 0.01,
-    use_sequence_loss: bool = False,
+    use_group_sequence_policy: bool = False,
     loss_mask: torch.Tensor = None
 ):
-    #torch.Size([8, 2048])
+
     logprobs_diff = log_probs - old_log_probs
     # clip logprobs_diff before exp to avoid overflow
-    if use_sequence_loss:
-        seq_negative_approx_kl = masked_mean(logprobs_diff.detach(), loss_mask, axis=1)
-        negative_approx_kl = log_probs - log_probs.detach() + seq_negative_approx_kl.unsqueeze(1)
-        logprobs_diff = torch.clamp(negative_approx_kl, max=diff_clip_ratio)
+    if use_group_sequence_policy:
+        logprobs_diff_mean = loss_masked_mean(logprobs_diff.detach(), loss_mask, axis=1)
+        seq_logprobs_diff = log_probs - log_probs.detach() + logprobs_diff_mean.unsqueeze(1)
+        logprobs_diff = torch.clamp(seq_logprobs_diff, max=diff_clip_ratio)
     else:
         logprobs_diff = torch.clamp(logprobs_diff, max=diff_clip_ratio)
 

--- a/chatlearn/algorithm/grpo_utils/loss_gallery.py
+++ b/chatlearn/algorithm/grpo_utils/loss_gallery.py
@@ -1,6 +1,28 @@
 """pg loss"""
 import torch
 
+def masked_sum(values, mask, axis=None):
+    """Compute mean of tensor with a masked values."""
+    # If NaNs exist out of mask, replace NaNs in values with a value that
+    # won't affect the sum (e.g., 0 for masked regions)
+    valid_values = torch.where(mask.bool(), values, 0.0)
+    return (valid_values * mask).sum(axis=axis)
+
+def masked_mean(values, mask, axis=None):
+    """
+    Compute the mean of `values` over elements selected by `mask`.
+
+    Args:
+        values (Tensor): Input tensor.
+        mask (Tensor): Boolean or numeric mask of the same shape as `values`.
+        axis (int or tuple of int, optional): Dimension(s) along which to compute the mean.
+            Defaults to None (over all elements).
+
+    Returns:
+        Tensor: Masked mean, with shape equal to `values` reduced over `axis`.
+    """
+    s = masked_sum(values, mask, axis)
+    return s / (mask.sum(axis=axis) + 1e-8)
 
 def calculate_grpo_loss(
     log_probs: torch.Tensor,
@@ -10,18 +32,33 @@ def calculate_grpo_loss(
     pos_clip_ratio: float = 0.2,
     neg_clip_ratio: float = 0.2,
     final_clip_ratio: float = 0.01,
+    use_sequence_loss: bool = False,
+    loss_mask: torch.Tensor = None
 ):
+    #torch.Size([8, 2048])
     logprobs_diff = log_probs - old_log_probs
     # clip logprobs_diff before exp to avoid overflow
-    logprobs_diff = torch.clamp(logprobs_diff, max=diff_clip_ratio)
+    if use_sequence_loss:
+        seq_negative_approx_kl = masked_mean(logprobs_diff.detach(), loss_mask, axis=1)
+        negative_approx_kl = log_probs - log_probs.detach() + seq_negative_approx_kl.unsqueeze(1)
+        logprobs_diff = torch.clamp(negative_approx_kl, max=diff_clip_ratio)
+    else:
+        logprobs_diff = torch.clamp(logprobs_diff, max=diff_clip_ratio)
 
     ratio = torch.exp(logprobs_diff)
-    pg_loss = -advantages.unsqueeze(-1) * ratio
+    advantages.unsqueeze_(-1)
+
+    pg_loss = -advantages * ratio
     # Upper and lower bound clip
-    pg_loss_2 = -advantages.unsqueeze(-1) * torch.clamp(
+    is_positive_clipped = (ratio > (1 + pos_clip_ratio)) * (advantages > 0)
+    is_negative_clipped = (ratio < (1 - neg_clip_ratio)) * (advantages < 0)
+
+    pg_loss_2 = -advantages * torch.clamp(
         ratio, 1 - neg_clip_ratio, 1 + pos_clip_ratio
     )
     pg_loss_clip = torch.max(pg_loss, pg_loss_2)
+
+    is_clipped = pg_loss_2 > pg_loss
     pg_loss_upperbound = torch.ones_like(pg_loss) * final_clip_ratio
     # final clip on loss
     loss = torch.min(pg_loss_clip, pg_loss_upperbound)
@@ -29,4 +66,9 @@ def calculate_grpo_loss(
     # check pg_loss nan
     assert not torch.isnan(loss).any(), "pg loss is nan"
 
-    return loss.contiguous()
+    return (
+        loss.contiguous(), 
+        is_positive_clipped, 
+        is_negative_clipped,
+        is_clipped,
+    )

--- a/chatlearn/algorithm/grpo_utils/loss_gallery.py
+++ b/chatlearn/algorithm/grpo_utils/loss_gallery.py
@@ -1,11 +1,6 @@
 """pg loss"""
 import torch
 
-def loss_masked_mean(values, loss_mask, axis=None):
-    valid_values = torch.where(loss_mask.bool(), values, 0.0)
-    s = (valid_values * loss_mask).sum(axis=axis)
-    return s / (loss_mask.sum(axis=axis) + 1e-8)
-
 def calculate_grpo_loss(
     log_probs: torch.Tensor,
     old_log_probs: torch.Tensor,
@@ -13,19 +8,52 @@ def calculate_grpo_loss(
     diff_clip_ratio: float = 10,
     pos_clip_ratio: float = 0.2,
     neg_clip_ratio: float = 0.2,
-    final_clip_ratio: float = 0.01,
-    use_group_sequence_policy: bool = False,
-    loss_mask: torch.Tensor = None
+    final_clip_ratio: float = 0.01
 ):
 
     logprobs_diff = log_probs - old_log_probs
     # clip logprobs_diff before exp to avoid overflow
-    if use_group_sequence_policy:
-        logprobs_diff_mean = loss_masked_mean(logprobs_diff.detach(), loss_mask, axis=1)
-        seq_logprobs_diff = log_probs - log_probs.detach() + logprobs_diff_mean.unsqueeze(1)
-        logprobs_diff = torch.clamp(seq_logprobs_diff, max=diff_clip_ratio)
-    else:
-        logprobs_diff = torch.clamp(logprobs_diff, max=diff_clip_ratio)
+    logprobs_diff = torch.clamp(logprobs_diff, max=diff_clip_ratio)
+
+    ratio = torch.exp(logprobs_diff)
+    advantages.unsqueeze_(-1)
+
+    pg_loss = -advantages * ratio
+    # Upper and lower bound clip
+    is_positive_clipped = (ratio > (1 + pos_clip_ratio)) * (advantages > 0)
+    is_negative_clipped = (ratio < (1 - neg_clip_ratio)) * (advantages < 0)
+
+    pg_loss_2 = -advantages * torch.clamp(
+        ratio, 1 - neg_clip_ratio, 1 + pos_clip_ratio
+    )
+    pg_loss_clip = torch.max(pg_loss, pg_loss_2)
+
+    is_clipped = pg_loss_2 > pg_loss
+    pg_loss_upperbound = torch.ones_like(pg_loss) * final_clip_ratio
+    # final clip on loss
+    loss = torch.min(pg_loss_clip, pg_loss_upperbound)
+
+    # check pg_loss nan
+    assert not torch.isnan(loss).any(), "pg loss is nan"
+
+    return loss.contiguous()
+
+def calculate_gspo_loss(
+    log_probs: torch.Tensor,
+    old_log_probs: torch.Tensor,
+    advantages: torch.Tensor,
+    diff_clip_ratio: float = 10,
+    pos_clip_ratio: float = 1e-3,
+    neg_clip_ratio: float = 1e-3,
+    final_clip_ratio: float = 0.01,
+    loss_mask: torch.Tensor = None
+):
+
+    logprobs_diff = log_probs - old_log_probs
+    valid_values = torch.where(loss_mask.bool(), logprobs_diff.detach(), 0.0)
+    logprobs_diff_mean = (valid_values * loss_mask).sum(axis=1) / (loss_mask.sum(axis=1) + 1e-8)
+    seq_logprobs_diff = log_probs - log_probs.detach() + logprobs_diff_mean.unsqueeze(1)
+    logprobs_diff = torch.clamp(seq_logprobs_diff, max=diff_clip_ratio)
 
     ratio = torch.exp(logprobs_diff)
     advantages.unsqueeze_(-1)

--- a/chatlearn/algorithm/grpo_utils/megatron_policy_trainer.py
+++ b/chatlearn/algorithm/grpo_utils/megatron_policy_trainer.py
@@ -271,7 +271,7 @@ class MegatronPolicyTrainer(MegatronModule):
             loss_reduced_for_metric = {
                 key: (
                     (loss_for_dp_reduce[i] / loss_for_dp_reduce[-1]).cpu().item()
-                    if key.endswith('_aligned') 
+                    if key.endswith('_sample_average') 
                     else (loss_for_dp_reduce[i] / loss_for_dp_reduce[-2]).cpu().item()
                 )
                 for i, key in enumerate(keys)

--- a/chatlearn/algorithm/grpo_utils/megatron_utils/policy_model.py
+++ b/chatlearn/algorithm/grpo_utils/megatron_utils/policy_model.py
@@ -27,7 +27,7 @@ from torch import Tensor
 
 from chatlearn.configs.common import BaseModelConfig
 
-from ..loss_gallery import calculate_grpo_loss
+from ..loss_gallery import calculate_grpo_loss, calculate_gspo_loss
 from .train_helper import entropy_from_tensor_parallel_logits
 
 class PolicyModel(GPTModel):
@@ -101,23 +101,32 @@ class PolicyModel(GPTModel):
             self.compute_language_model_loss(labels, all_token_logits) * -1
         )
 
-        (
-            pg_loss, 
-            is_positive_clipped, 
-            is_negative_clipped,
-            is_clipped,
-        ) = calculate_grpo_loss(
-            log_probs=forward_logprob,
-            old_log_probs=old_logprobs,
-            advantages=advantages,
-            diff_clip_ratio=self.module_args.diff_clip_ratio,
-            pos_clip_ratio=self.module_args.pos_clip_ratio,
-            neg_clip_ratio=self.module_args.neg_clip_ratio,
-            final_clip_ratio=self.module_args.final_clip_ratio,
-            use_group_sequence_policy=self.module_args.use_group_sequence_policy,
-            loss_mask = training_inputs['all_token_loss_mask']
-        )
-
+        if self.module_args.use_group_sequence_policy:
+            (
+                pg_loss, 
+                is_positive_clipped, 
+                is_negative_clipped,
+                is_clipped,
+            ) = calculate_gspo_loss(
+                log_probs=forward_logprob,
+                old_log_probs=old_logprobs,
+                advantages=advantages,
+                diff_clip_ratio=self.module_args.diff_clip_ratio,
+                pos_clip_ratio=self.module_args.pos_clip_ratio,
+                neg_clip_ratio=self.module_args.neg_clip_ratio,
+                final_clip_ratio=self.module_args.final_clip_ratio,
+                loss_mask = training_inputs['all_token_loss_mask']
+            )
+        else:
+            pg_loss = calculate_grpo_loss(
+                log_probs=forward_logprob,
+                old_log_probs=old_logprobs,
+                advantages=advantages,
+                diff_clip_ratio=self.module_args.diff_clip_ratio,
+                pos_clip_ratio=self.module_args.pos_clip_ratio,
+                neg_clip_ratio=self.module_args.neg_clip_ratio,
+                final_clip_ratio=self.module_args.final_clip_ratio
+            )
         entropy_loss = entropy_from_tensor_parallel_logits(all_token_logits).transpose(0, 1)
 
         kl = ref_logprobs - forward_logprob
@@ -127,15 +136,21 @@ class PolicyModel(GPTModel):
         kld = (ratio - kl - 1).contiguous()
         kl_loss = torch.clamp(kld, min=-10, max=10)
 
-        return {
-            'pg_loss': pg_loss,
-            'entropy_loss': entropy_loss,
-            'kl_loss': kl_loss,
-            'is_positive_clipped': is_positive_clipped,
-            'is_negative_clipped': is_negative_clipped,
-            'is_clipped': is_clipped,
-            # NOTE: aligned will compute per-token-metric in microbatch and average between microbatch
-            'is_positive_clipped_aligned': is_positive_clipped,
-            'is_negative_clipped_aligned': is_negative_clipped,
-            'is_clipped_aligned': is_clipped,
-        }
+        if self.module_args.use_group_sequence_policy:
+            return {
+                'pg_loss': pg_loss,
+                'entropy_loss': entropy_loss,
+                'kl_loss': kl_loss,
+                'is_positive_clipped': is_positive_clipped,
+                'is_negative_clipped': is_negative_clipped,
+                'is_clipped': is_clipped,
+                'is_positive_clipped_sample_average': is_positive_clipped,
+                'is_negative_clipped_sample_average': is_negative_clipped,
+                'is_clipped_sample_average': is_clipped,
+            }
+        else:
+            return {
+                'pg_loss': pg_loss,
+                'entropy_loss': entropy_loss,
+                'kl_loss': kl_loss
+            }

--- a/chatlearn/algorithm/grpo_utils/megatron_utils/policy_model.py
+++ b/chatlearn/algorithm/grpo_utils/megatron_utils/policy_model.py
@@ -114,6 +114,7 @@ class PolicyModel(GPTModel):
             pos_clip_ratio=self.module_args.pos_clip_ratio,
             neg_clip_ratio=self.module_args.neg_clip_ratio,
             final_clip_ratio=self.module_args.final_clip_ratio,
+            use_group_sequence_policy=self.module_args.use_group_sequence_policy,
             loss_mask = training_inputs['all_token_loss_mask']
         )
 

--- a/chatlearn/algorithm/grpo_utils/megatron_utils/train_helper.py
+++ b/chatlearn/algorithm/grpo_utils/megatron_utils/train_helper.py
@@ -281,7 +281,7 @@ def loss_func(
     for key, loss in losses.items():
         if key not in require_bp_keys:
             loss = loss.detach()
-        if key.endswith('_aligned'):
+        if key.endswith('_sample_average'):
             final_loss = (loss.float() * loss_mask).sum() / (1e-5 + loss_mask.sum())
         else:
             final_loss = (loss.float() * loss_mask).sum()

--- a/chatlearn/algorithm/grpo_utils/megatron_utils/train_helper.py
+++ b/chatlearn/algorithm/grpo_utils/megatron_utils/train_helper.py
@@ -281,7 +281,10 @@ def loss_func(
     for key, loss in losses.items():
         if key not in require_bp_keys:
             loss = loss.detach()
-        final_loss = (loss.float() * loss_mask).sum()
+        if key.endswith('_aligned'):
+            final_loss = (loss.float() * loss_mask).sum() / (1e-5 + loss_mask.sum())
+        else:
+            final_loss = (loss.float() * loss_mask).sum()
         if key in require_bp_keys:
             total_loss_for_bp = total_loss_for_bp + final_loss
 
@@ -289,6 +292,7 @@ def loss_func(
 
     num_tokens = loss_mask.sum().clone().detach().to(torch.int)
     reporting_losses["num_tokens"] = num_tokens
+    reporting_losses["num_samples"] = torch.ones_like(num_tokens)
     return total_loss_for_bp, num_tokens, reporting_losses
 
 

--- a/chatlearn/configs/common.py
+++ b/chatlearn/configs/common.py
@@ -311,6 +311,9 @@ class PolicyTrainerConfig(BaseModelConfig, FSDPConfig):
     pos_clip_ratio: float = field(default=0.2)
     neg_clip_ratio: float = field(default=0.2)
     save_hf: bool = field(default=True)
+    use_group_sequence_policy: bool = field(
+        default=False, metadata={"help": "whether to use group sequence policy optimization"}
+    )
 
 
 @dataclass

--- a/chatlearn/configs/megatron_config.py
+++ b/chatlearn/configs/megatron_config.py
@@ -358,3 +358,4 @@ class MegatronPolicyTrainerConfig(
     diff_clip_ratio: float = field(default=10)
     final_clip_ratio: float = field(default=3)
     seed: int = field(default=1234, metadata={"help": "seed"})
+    use_group_sequence_policy: bool = field(default=False)

--- a/scripts/train_mcore_vllm_qwen3_30b_gspo.sh
+++ b/scripts/train_mcore_vllm_qwen3_30b_gspo.sh
@@ -55,8 +55,8 @@ python chatlearn/entrypoint.py grpo --config-file template/grpo_megatron.yaml \
         models.policy_trainer.log_interval=1 \
         models.policy_trainer.optimizer.lr=2e-6 \
         models.policy_trainer.optimizer.min_lr=2e-6 \
-        models.policy_trainer.pos_clip_ratio=0.2 \
-        models.policy_trainer.neg_clip_ratio=0.2 \
+        models.policy_trainer.pos_clip_ratio=1e-3 \
+        models.policy_trainer.neg_clip_ratio=1e-3 \
         models.policy_trainer.use_group_sequence_policy=true \
         models.reward.generation_batch_size=128 \
         models.policy.load=${hf_ckpt_path} \

--- a/scripts/train_mcore_vllm_qwen3_30b_gspo.sh
+++ b/scripts/train_mcore_vllm_qwen3_30b_gspo.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -x
+
+export RAY_CGRAPH_get_timeout=200
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export RAY_DEDUP_LOGS=1
+export VLLM_USE_RAY_SPMD_WORKER=1
+export VLLM_USE_RAY_COMPILED_DAG=1
+
+export CHATLEARN=$(pwd)
+export MEGATRON_PATH=${CHATLEARN}/../Pai-Megatron-Patch/backends/megatron/Megatron-LM-250624
+export PYTHONPATH=${CHATLEARN}:${MEGATRON_PATH}:${PYTHONPATH}
+source scripts/base_env.sh
+
+hf_ckpt_path=${CHATLEARN}/pretrained_models/Qwen3-30B-A3B
+mcore_ckpt_path=${CHATLEARN}/pretrained_models/Qwen3-30B-A3B-to-mcore
+
+exp_name="test_qwen3_30b_gspo"
+export output_dir=${CHATLEARN}/output/${exp_name}
+mkdir -p $output_dir/
+export log_dir=${output_dir}/logs
+mkdir -p $log_dir
+log_file=$log_dir/${exp_name}_rank${RANK}.log
+
+python chatlearn/entrypoint.py grpo --config-file template/grpo_megatron.yaml \
+        runtime_args.exp_name=${exp_name} \
+        runtime_args.log_args_dict.enable_tensorboard=True \
+        runtime_args.train_backend=megatron \
+        runtime_args.data_path=${CHATLEARN}/dataset/MATH-lighteval/train.json \
+        runtime_args.eval_data_path=${CHATLEARN}/dataset/MATH-lighteval/test.json \
+        runtime_args.output_dir=${CHATLEARN}/output/${exp_name} \
+        runtime_args.num_episode=100 \
+        runtime_args.sample_per_episode=1024 \
+        runtime_args.train_global_batch_size=256 \
+        runtime_args.train_micro_batch_size=1 \
+        runtime_args.save_episode_interval=1000000 \
+        runtime_args.log_args_dict.enable_tensorboard=true \
+        runtime_args.log_args_dict.tensorboard_dir=${output_dir}/tensorboard \
+        runtime_args.eval_episode_interval=1 \
+        runtime_args.enable_eval_before_training=false \
+        models.policy_trainer.num_gpu=${num_device} \
+        models.policy_trainer.bf16=true \
+        models.policy_trainer.sequence_parallel=true \
+        models.policy_trainer.use_distributed_optimizer=true \
+        models.policy_trainer.recompute_granularity='selective' \
+        models.policy_trainer.train_iters=100 \
+        models.policy_trainer.seq_length=2048 \
+        models.policy_trainer.tensor_model_parallel_size=4 \
+        models.policy_trainer.pipeline_model_parallel_size=2 \
+        models.policy_trainer.expert_tensor_parallel_size=4 \
+        models.policy_trainer.expert_model_parallel_size=1 \
+        models.policy_trainer.generation_batch_size=32 \
+        models.policy_trainer.load=${mcore_ckpt_path} \
+        models.policy_trainer.save_interval=1000000 \
+        models.policy_trainer.log_interval=1 \
+        models.policy_trainer.optimizer.lr=2e-6 \
+        models.policy_trainer.optimizer.min_lr=2e-6 \
+        models.policy_trainer.pos_clip_ratio=0.2 \
+        models.policy_trainer.neg_clip_ratio=0.2 \
+        models.policy_trainer.use_group_sequence_policy=true \
+        models.reward.generation_batch_size=128 \
+        models.policy.load=${hf_ckpt_path} \
+        models.policy.generation_batch_size=128 \
+        models.policy.tensor_model_parallel_size=4 \
+        models.policy.seq_length=2048 \
+        models.policy.max_seq_len_to_capture=2348 \
+        models.policy.num_inference_per_prompt=32 \
+        models.policy.gpu_memory_utilization=0.75 \
+        models.policy.enable_thinking=True \
+        2>&1 | tee ${log_file} ; exit ${PIPESTATUS[0]}

--- a/template/grpo_megatron.yaml
+++ b/template/grpo_megatron.yaml
@@ -70,6 +70,7 @@ models:
     # other 
     pos_clip_ratio: 0.2
     neg_clip_ratio: 0.2
+    use_group_sequence_policy: False
     diff_clip_ratio: 10
     final_clip_ratio: 3
   ref_policy:


### PR DESCRIPTION
Please check our GSPO efficiency over GRPO
<img width="1472" height="900" alt="image" src="https://github.com/user-attachments/assets/e0d42e9a-c1a2-4af7-9c32-fb47b237ea6b" />

Below is our average fractions of clipped tokens over the RL training of GSPO and GRPO. 
<img width="1514" height="820" alt="image" src="https://github.com/user-attachments/assets/ae1b728d-98f2-4d64-8ef6-11dba40b04ba" />

Please use scripts/train_mcore_vllm_qwen3_30b_gspo.sh to reproduce our results, also please follow below diff to modify Megatron-LM-250624 backends used by ChatLearn.
<img width="1998" height="476" alt="image" src="https://github.com/user-attachments/assets/3a22e7ae-ed9d-4a73-a29b-2a21062430a7" />