### PR TITLE
fix mcore recompute_granularity is full and add trust_remote_code for mcore 250908

### DIFF
--- a/chatlearn/algorithm/grpo_utils/megatron_utils/train_helper.py
+++ b/chatlearn/algorithm/grpo_utils/megatron_utils/train_helper.py
@@ -512,3 +512,4 @@ def entropy_from_tensor_parallel_logits(logits: torch.Tensor) -> torch.Tensor:
         logits: (*, vocab_size // tp_size)
     """
     return _VocabParallelEntropy.apply(logits)
+    

--- a/chatlearn/algorithm/grpo_utils/megatron_utils/train_helper.py
+++ b/chatlearn/algorithm/grpo_utils/megatron_utils/train_helper.py
@@ -259,12 +259,11 @@ def get_batch(
     prompt_token_length = to_device("cuda", data_b["prompt_token_length"])
     response_token_length = to_device("cuda", data_b["response_token_length"])
 
-    tp_size = mpu.get_tensor_model_parallel_world_size()
-    cp_size = mpu.get_context_parallel_world_size()
-    align_size = tp_size * cp_size * 2
-
     if is_packing:
+        tp_size = mpu.get_tensor_model_parallel_world_size()
+        cp_size = mpu.get_context_parallel_world_size()
         cp_rank = mpu.get_context_parallel_group().rank()
+        align_size = tp_size * cp_size * 2
         attn_mask = torch.zeros_like(tokens, dtype=torch.int32)
         for i, (prompt_length, response_length) in enumerate(
             zip(prompt_token_length, response_token_length)
@@ -332,8 +331,16 @@ def get_batch(
         }
 
     else:
-        pad_size = (align_size - tokens.shape[1] % align_size) % align_size
-        tokens = F.pad(tokens, (0, pad_size), value=get_tokenizer().eod)
+        pad_size = 0
+        pad_token = get_tokenizer().eod
+        if not args.variable_seq_lengths:
+            pad_size = args.seq_length - tokens.shape[1]
+        else:
+            divisor = mpu.get_tensor_model_parallel_world_size()
+            total_nnz = tokens.shape[1]
+            pad_size = (divisor - total_nnz % divisor) % divisor
+
+        tokens = F.pad(tokens, (0, pad_size), value=pad_token)
         labels = torch.roll(tokens, shifts=-1, dims=1)
         attention_mask, _, position_ids = get_ltor_masks_and_position_ids(
             tokens,

--- a/chatlearn/algorithm/grpo_utils/rollout_manager.py
+++ b/chatlearn/algorithm/grpo_utils/rollout_manager.py
@@ -30,7 +30,7 @@ class RolloutManager(BaseModule):
     def build_dataset(self, prompts: List[Dict], is_eval=False):
         # prompts seems like the total data set by engine.set_dataset(dataset)
         # TODO: move dataset to seperate node
-        self.tokenizer = AutoTokenizer.from_pretrained(self.module_args.load, trust_remote_code=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.module_args.load, trust_remote_code=self.module_args.trust_remote_code)
         prompts_dataset = PromptPipeline(
             prompts,
             sum(self.max_token_per_round),

--- a/chatlearn/configs/base/base_model_config.py
+++ b/chatlearn/configs/base/base_model_config.py
@@ -72,6 +72,6 @@ class BaseModelConfig(BaseConfig):
         metadata={"help": "The number of replica of this model."}
     )
     trust_remote_code: bool = field(
-        default=False, metadata={"help": "Whether or not to allow PreTrainedTokenizer to execute remote code"}
+        default=True, metadata={"help": "Whether or not to allow PreTrainedTokenizer to execute remote code"}
     )
     

--- a/chatlearn/configs/base/base_model_config.py
+++ b/chatlearn/configs/base/base_model_config.py
@@ -71,4 +71,7 @@ class BaseModelConfig(BaseConfig):
         default=1,
         metadata={"help": "The number of replica of this model."}
     )
+    trust_remote_code: bool = field(
+        default=False, metadata={"help": "Whether or not to allow PreTrainedTokenizer to execute remote code"}
+    )
     

--- a/chatlearn/configs/megatron_config.py
+++ b/chatlearn/configs/megatron_config.py
@@ -233,6 +233,9 @@ class MegatronConfig(BaseConfig):
     tokenizer_type: str = field(
         default="NullTokenizer", metadata={"help": "What type of tokenizer to use."}
     )
+    trust_remote_code: bool = field(
+        default=False, metadata={"help": "Whether or not to allow PreTrainedTokenizer to execute remote code"}
+    )
     tokenizer_model: Optional[str] = field(
         default=None, metadata={"help": "pretrained model name or path. If None, use cfg.load instead"}
     )

--- a/chatlearn/configs/megatron_config.py
+++ b/chatlearn/configs/megatron_config.py
@@ -233,9 +233,6 @@ class MegatronConfig(BaseConfig):
     tokenizer_type: str = field(
         default="NullTokenizer", metadata={"help": "What type of tokenizer to use."}
     )
-    trust_remote_code: bool = field(
-        default=False, metadata={"help": "Whether or not to allow PreTrainedTokenizer to execute remote code"}
-    )
     tokenizer_model: Optional[str] = field(
         default=None, metadata={"help": "pretrained model name or path. If None, use cfg.load instead"}
     )

--- a/chatlearn/configs/megatron_config.py
+++ b/chatlearn/configs/megatron_config.py
@@ -320,6 +320,22 @@ class MegatronPolicyTrainerConfig(PolicyTrainerConfig, MegatronConfig):
             2) selective: submodules set in --recompute-modules are recomputed, default is core_attn."
         },
     )
+    recompute_method: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "1) uniform: uniformly divide the total number of Transformer layers \
+            and recompute the input activation of each divided chunk at specified granularity,  \
+            2) recompute the input activations of only a set number of individual Transformer layers per pipeline stage and do the \
+            rest without any recomputing at specified granularity default) do not apply activations recompute to any layers."
+        },
+    )
+    recompute_num_layers: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "1) uniform: the number of Transformer layers in each uniformly divided recompute unit, \
+            2) block: the number of individual Transformer layers to recompute within each pipeline stage."
+        },
+    )
     use_distributed_optimizer: bool = field(
         default=False,
         metadata={"help": "use_distributed_optimizer"},

--- a/chatlearn/models/fsdp_module.py
+++ b/chatlearn/models/fsdp_module.py
@@ -165,7 +165,7 @@ class FSDPModule(TorchModule):
                     pretrained_model_name_or_path=model_path,
                     torch_dtype=torch_dtype,
                     attn_implementation="flash_attention_2",
-                    trust_remote_code=True
+                    trust_remote_code=self.module_args.trust_remote_code
                 )
 
                 from chatlearn.models.patches.monkey_patch import apply_qwenvl
@@ -176,7 +176,7 @@ class FSDPModule(TorchModule):
                     pretrained_model_name_or_path=model_path,
                     torch_dtype=torch_dtype,
                     attn_implementation="flash_attention_2",
-                    trust_remote_code=True,
+                    trust_remote_code=self.module_args.trust_remote_code,
                 )
         else:
             model_config = AutoConfig.from_pretrained(model_path)
@@ -186,7 +186,7 @@ class FSDPModule(TorchModule):
                     model_config,
                     torch_dtype=torch_dtype,
                     attn_implementation="flash_attention_2",
-                    trust_remote_code=True
+                    trust_remote_code=self.module_args.trust_remote_code
                 )
         dist.barrier()
         return model
@@ -246,7 +246,7 @@ class FSDPModule(TorchModule):
             self.create_sp_device_mesh()
             apply_sp_monkey_patch(model.config)
         self.tokenizer = AutoTokenizer.from_pretrained(
-            args.load, trust_remote_code=True, use_fast=True
+            args.load, trust_remote_code=self.module_args.trust_remote_code, use_fast=True
         )
         model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={'use_reentrant': False})
 

--- a/chatlearn/models/sglang_module.py
+++ b/chatlearn/models/sglang_module.py
@@ -222,7 +222,7 @@ class SGLangModule(TorchModule):
     def setup(self):
         super().setup()
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self.module_args["load"], trust_remote_code=True
+            self.module_args["load"], trust_remote_code=self.module_args.trust_remote_code
         )
 
     @timeit()
@@ -266,7 +266,7 @@ class SGLangModule(TorchModule):
                 load_format=load_format,
                 dist_init_addr=dist_init_addr,
                 nnodes=nnodes_per_replica,
-                trust_remote_code=True,
+                trust_remote_code=self.module_args.trust_remote_code,
                 port=40000 + self.replica_id,
                 nccl_port=int(os.environ["SGLANG_NCCL_PORT"]),
                 mm_attention_backend="fa3",
@@ -505,7 +505,7 @@ class SGLangModule(TorchModule):
         with torch.device('meta'):
             meta_model = AutoModelForCausalLM.from_config(
                 model_config,
-                trust_remote_code=True
+                trust_remote_code=self.module_args.trust_remote_code
             )
         names = list(meta_model.state_dict().keys())
         self.global_name_to_local_name = {n: n for n in names}
@@ -522,7 +522,7 @@ class SGLangModule(TorchModule):
         with torch.device('meta'):
             meta_model = AutoModelForCausalLM.from_config(
                 model_config,
-                trust_remote_code=True
+                trust_remote_code=self.module_args.trust_remote_code
             )
         infos = {}
         for name, sharded_info in build_sharded_info_for_huggingface_model(meta_model).items():

--- a/chatlearn/models/vllm_module.py
+++ b/chatlearn/models/vllm_module.py
@@ -125,7 +125,7 @@ if HAVE_VLLM:
                 # logger
                 disable_log_requests=self.module_args.get("disable_log_requests", True),
                 disable_log_stats=self.module_args.get("disable_log_stats", True),
-                trust_remote_code=True,
+                trust_remote_code=self.module_args.trust_remote_code,
                 enforce_eager=self.module_args.get("enforce_eager", True),
                 disable_custom_all_reduce=True,
                 distributed_executor_backend="ray",
@@ -157,13 +157,13 @@ if HAVE_VLLM:
             """
             super().setup()
 
-            tokenizer = AutoTokenizer.from_pretrained(self.module_args['load'], trust_remote_code=True)
+            tokenizer = AutoTokenizer.from_pretrained(self.module_args['load'], trust_remote_code=self.module_args.trust_remote_code)
             tokenizer.tokenizer = tokenizer
             self.tokenizer = tokenizer
 
             if '<|vision_start|>' in tokenizer.additional_special_tokens:
                 # processor is needed for qwenvl
-                self.processor = AutoProcessor.from_pretrained(self.module_args['load'], trust_remote_code=True)
+                self.processor = AutoProcessor.from_pretrained(self.module_args['load'], trust_remote_code=self.module_args.trust_remote_code)
             else:
                 self.processor = None
 
@@ -208,7 +208,7 @@ if HAVE_VLLM:
                 # logger
                 disable_log_requests=self.module_args.get("disable_log_requests", True),
                 disable_log_stats=self.module_args.get("disable_log_stats", True),
-                trust_remote_code=True,
+                trust_remote_code=self.module_args.trust_remote_code,
                 enforce_eager=self.module_args.get("enforce_eager", False),
                 disable_custom_all_reduce=True,
                 distributed_executor_backend="ray",

--- a/chatlearn/synchronizer/mappers/mapper.py
+++ b/chatlearn/synchronizer/mappers/mapper.py
@@ -254,7 +254,7 @@ class MegatronMapper:
             # NOTE: if transformer.config have n_shared_experts, mapping to `shared_experts`, otherwise `shared_expert`
             # `shared_experts`: DeepSeek-V2, DeepSeek-V3, etc.
             # `shared_expert`: Qwen2-MoE, LLaMA-4, etc.
-            hf_config = AutoConfig.from_pretrained(self._dst_model_config.load, trust_remote_code=True)
+            hf_config = AutoConfig.from_pretrained(self._dst_model_config.load, trust_remote_code=self._dst_model_config.trust_remote_code)
             shared_expert_key = 'shared_experts' if hasattr(hf_config, 'n_shared_experts') else 'shared_expert'
             self._update_mapping(self._map_mlp(
                 module.shared_experts,

--- a/docs/en/config.md
+++ b/docs/en/config.md
@@ -145,6 +145,7 @@ policy_trainer:
 - `models.policy_trainer.seq_length`: Sequence length for Megatron Training. If `models.policy_trainer.packing` is enabled, the value will be ignored.
 Otherwise, the value must be equal to the value used for data generation.
 - `models.policy_trainer.tokenizer_type`: Tokenizer type for Megatron Training. For most cases, HuggingFaceTokenizer is recommended.
+- `models.policy_trainer.trust_remote_code`: Whether or not to allow Tokenizer to execute remote code, HuggingFaceTokenizer is recommended.
 - `models.policy_trainer.tokenizer_model`: Path to the tokenizer model for Megatron training.
 - `models.policy_trainer.tensor_model_parallel_size`: Tensor model parallel world size.
 - `models.policy_trainer.pipeline_model_parallel_size`: Pipeline model parallel world size.
@@ -158,6 +159,8 @@ Otherwise, the value must be equal to the value used for data generation.
 - `models.policy_trainer.sequence_parallel`: Whether to use sequence parallelism. Valid when `tensor_model_parallel_size` larger than 1.
 - `models.policy_trainer.use_distributed_optimizer`: Whether to use distributed optimizer to reduce memory consumption. Recommended to set True.
 - `models.policy_trainer.recompute_granularity`: Select recompute granularity to save memory usage. Should be null, `sel` or `full`. 
+- `models.policy_trainer.recompute_method`: When recompute_granularity is full, select recompute_method to recompute. Should be null, `uniform` or `block`. 
+- `models.policy_trainer.recompute_num_layers`: When recompute_granularity is full, select recompute_num_layers to recompute. Should be null or `num_layers`. 
 - `models.policy_trainer.use_group_sequence_policy`: Whether to use [GSPO](https://qwenlm.github.io/blog/gspo/).
 
 

--- a/template/grpo_megatron.yaml
+++ b/template/grpo_megatron.yaml
@@ -46,6 +46,7 @@ models:
     bf16: True
     seq_length: 2048
     tokenizer_type: 'HuggingFaceTokenizer'
+    trust_remote_code: False
     tokenizer_model: ${models.policy.load}
     trainable: True
     generation_batch_size: 8
@@ -79,7 +80,8 @@ models:
       offload_weights: True
     generation_batch_size: ${models.policy_trainer.generation_batch_size}
     seq_length: ${models.policy_trainer.seq_length}
-    tokenizer_type: 'HuggingFaceTokenizer'
+    tokenizer_type: ${models.policy_trainer.tokenizer_type}
+    trust_remote_code: ${models.policy_trainer.trust_remote_code}
     tokenizer_model: ${models.policy.load}
     bf16: True
     sequence_parallel: True

--- a/template/grpo_megatron.yaml
+++ b/template/grpo_megatron.yaml
@@ -66,6 +66,8 @@ models:
     sequence_parallel: True
     use_distributed_optimizer: True
     recompute_granularity: null
+    recompute_method: null
+    recompute_num_layers: null
     # other 
     pos_clip_ratio: 0.2
     neg_clip_ratio: 0.2

--- a/template/grpo_megatron.yaml
+++ b/template/grpo_megatron.yaml
@@ -108,6 +108,7 @@ models:
     num_gpu: ${models.policy_trainer.num_gpu}
     trainable: False
     # args_dict:
+    trust_remote_code: ${models.policy_trainer.trust_remote_code}
     load: your_hf_model_path
     num_inference_per_prompt: ${runtime_args.num_inference_per_prompt}
     seq_length: 2048


### PR DESCRIPTION
1. Add recompute_method and recompute_num_layers configs to support recompute_granularity=full
2. In Mcore 250908, it supports trust-remote-code, therefore wen don't need to modify mcore backend to adapt Moonlight 
